### PR TITLE
feat(providers): add concept of providers; update to support FWF

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
-Monitor GH auth tokens for problems like upcoming expiration
+Monitor auth tokens for problems like upcoming expiration
+
+Currently supported providers:
+ - `github` : [GitHub](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens)
+ - `fwf` : [Fermyon Wasm Functions](https://www.fermyon.com/wasm-functions)
 
 # Usage
 

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -23,20 +24,25 @@ import (
 	"go.opentelemetry.io/otel/codes"
 	sdkTrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/trace"
+
+	"github.com/fermyon/github-token-monitor/providers"
 )
 
-const (
+var timestampLayouts = []string{
 	// Sometimes Github returns an abbreviated timezone name, sometimes a numeric offset 🙄
-	abbrevLayout = "2006-01-02 15:04:05 MST"
-	offsetLayout = "2006-01-02 15:04:05 -0700"
-)
+	"2006-01-02 15:04:05 MST",
+	"2006-01-02 15:04:05 -0700",
+	// This is the current layout for FwF
+	"2006-01-02 15:04:05.999999 -0700 MST",
+}
 
 var flags struct {
 	TokenEnvVars []string `name:"token-env-vars" help:"Comma-separated list of token env var(s)"`
 	TokensDir    string   `name:"tokens-dir" help:"Directory containing mounted secret tokens"`
 
-	BaseURL             *url.URL      `name:"base-url" default:"https://api.github.com" help:"GitHub API base URL"`
-	ExpirationThreshold time.Duration `name:"expiration-threshold" default:"360h" help:"Minimum duration until token expiration"`
+	BaseURL             *url.URL           `name:"base-url" help:"Token API base URL (overrides provider default)"`
+	ExpirationThreshold time.Duration      `name:"expiration-threshold" default:"360h" help:"Minimum duration until token expiration"`
+	Provider            providers.Provider `name:"provider" type:"" default:"github" help:"Auth Token provider ('github' or 'fwf')" `
 }
 
 func main() {
@@ -49,6 +55,10 @@ func main() {
 
 func run() error {
 	kong.Parse(&flags)
+
+	if flags.BaseURL != nil {
+		flags.Provider.BaseURL = flags.BaseURL
+	}
 
 	ctx := context.Background()
 
@@ -83,8 +93,8 @@ func checkTokens(ctx context.Context) (err error) {
 		span.End()
 	}()
 	span.SetAttributes(
-		attribute.Stringer("ghtokmon.base_url", flags.BaseURL),
-		attribute.Float64("ghtokmon.expiration_threshold", flags.ExpirationThreshold.Seconds()))
+		attribute.Stringer("tokmon.base_url", flags.Provider.BaseURL),
+		attribute.Float64("tokmon.expiration_threshold", flags.ExpirationThreshold.Seconds()))
 
 	tokens := map[string]string{}
 
@@ -129,7 +139,7 @@ func checkTokens(ctx context.Context) (err error) {
 			}
 		}
 	}
-	span.SetAttributes(attribute.StringSlice("ghtokmon.tokens", slices.Collect(maps.Keys(tokens))))
+	span.SetAttributes(attribute.StringSlice("tokmon.tokens", slices.Collect(maps.Keys(tokens))))
 
 	if len(tokens) == 0 {
 		return fmt.Errorf("no tokens to check")
@@ -159,18 +169,20 @@ func checkToken(ctx context.Context, name, token string) (happy bool, err error)
 		}
 		span.End()
 	}()
-	span.SetAttributes(attribute.String("ghtokmon.token.name", name))
+	span.SetAttributes(attribute.String("tokmon.token.name", name))
 
-	fmt.Printf("Checking %q...\n", name)
+	fmt.Printf("Checking %q with provider %q...\n", name, flags.Provider.Name)
 
 	// Make request to check token
-	resp, _, err := request(ctx, flags.BaseURL.String(), token)
+	url := flags.Provider.BaseURL.JoinPath(flags.Provider.Path).String()
+	resp, _, err := request(ctx, url, token)
 	if err != nil {
-		return false, fmt.Errorf("checking token: %w", err)
+		return false, fmt.Errorf("checking token via url %s: %w", url, err)
 	}
 
 	// Get user info (if permitted)
-	userURL := flags.BaseURL.JoinPath("user").String()
+	// TODO: Currently only valid with GitHub; request support in FwF as well?
+	userURL := flags.Provider.BaseURL.JoinPath("user").String()
 	_, userJSON, err := request(ctx, userURL, token)
 	if err == nil {
 		// Parse user login
@@ -181,23 +193,27 @@ func checkToken(ctx context.Context, name, token string) (happy bool, err error)
 		if err != nil {
 			return false, fmt.Errorf("deserializing user: %w", err)
 		}
-		span.SetAttributes(attribute.String("ghtokmon.token.login", user.Login))
+		span.SetAttributes(attribute.String("tokmon.token.login", user.Login))
 		fmt.Printf("Token user login: %s\n", user.Login)
 	}
 
 	happy = true
 
 	// Check token expiration
-	expirationValue := resp.Header.Get("github-authentication-token-expiration")
+	expirationValue := resp.Header.Get(flags.Provider.AuthHeader)
 	if expirationValue == "" {
 		fmt.Println("Token expiration: NONE")
 	} else {
-		span.SetAttributes(attribute.String("ghtokmon.token.expiration", expirationValue))
+		span.SetAttributes(attribute.String("tokmon.token.expiration", expirationValue))
 
 		// Parse expiration timestamp
-		expiration, err := time.Parse(abbrevLayout, expirationValue)
-		if err != nil {
-			expiration, err = time.Parse(offsetLayout, expirationValue)
+		var expiration time.Time
+		var err error
+		for _, layout := range timestampLayouts {
+			expiration, err = time.Parse(layout, expirationValue)
+			if err == nil {
+				break
+			}
 		}
 		if err != nil {
 			return false, fmt.Errorf("invalid expiration header value %q: %w", expirationValue, err)
@@ -206,7 +222,7 @@ func checkToken(ctx context.Context, name, token string) (happy bool, err error)
 
 		// Calculate time until expiration
 		expirationDuration := time.Until(expiration)
-		span.SetAttributes(attribute.Float64("ghtokmon.token.expiration_duration", expirationDuration.Seconds()))
+		span.SetAttributes(attribute.Float64("tokmon.token.expiration_duration", expirationDuration.Seconds()))
 		fmt.Printf(" (%.1f days)\n", expirationDuration.Hours()/24)
 		if expirationDuration < flags.ExpirationThreshold {
 			fmt.Println("WARNING: Expiring soon!")
@@ -231,10 +247,12 @@ func checkToken(ctx context.Context, name, token string) (happy bool, err error)
 		}
 	}
 
-	// Get token permissions (sometimes helpful when rotating)
-	oAuthScopes := resp.Header.Get("x-oauth-scopes")
-	span.SetAttributes(attribute.String("ghtokmon.token.oauth_scopes", oAuthScopes))
-	fmt.Printf("OAuth scopes: %s\n\n", oAuthScopes)
+	// Get GitHub token permissions (sometimes helpful when rotating)
+	if flags.Provider == providers.Github {
+		oAuthScopes := resp.Header.Get("x-oauth-scopes")
+		span.SetAttributes(attribute.String("tokmon.token.oauth_scopes", oAuthScopes))
+		fmt.Printf("OAuth scopes: %s\n\n", oAuthScopes)
+	}
 	return happy, nil
 }
 
@@ -247,11 +265,21 @@ func request(ctx context.Context, url, token string) (resp *http.Response, body 
 		span.End()
 	}()
 
-	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
-	if err != nil {
-		return nil, nil, fmt.Errorf("new request: %w", err)
+	var req *http.Request
+	switch flags.Provider {
+	case providers.Fwf:
+		body := []byte(`{}`)
+		req, err = http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(body))
+		if err != nil {
+			return nil, nil, fmt.Errorf("new request: %w", err)
+		}
+		req.Header.Set("Content-Type", "application/json")
+	default:
+		req, err = http.NewRequestWithContext(ctx, "GET", url, nil)
+		if err != nil {
+			return nil, nil, fmt.Errorf("new request: %w", err)
+		}
 	}
-
 	req.Header.Set("Authorization", "Bearer "+token)
 
 	resp, err = http.DefaultClient.Do(req)
@@ -265,12 +293,12 @@ func request(ctx context.Context, url, token string) (resp *http.Response, body 
 		return nil, nil, fmt.Errorf("reading body: %w", err)
 	}
 
-	if resp.StatusCode != 200 {
+	if resp.StatusCode != flags.Provider.ExpectedStatusCode {
 		if len(body) > 1024 {
 			body = body[:1024]
 		}
-		trace.SpanFromContext(ctx).SetAttributes(attribute.String("ghtokmon.error_body", strconv.QuoteToASCII(string(body))))
-		return nil, nil, fmt.Errorf("got status code %d != 200", resp.StatusCode)
+		trace.SpanFromContext(ctx).SetAttributes(attribute.String("tokmon.error_body", strconv.QuoteToASCII(string(body))))
+		return nil, nil, fmt.Errorf("got status code %d != %d", resp.StatusCode, flags.Provider.ExpectedStatusCode)
 	}
 	return
 }

--- a/providers/fwf.go
+++ b/providers/fwf.go
@@ -1,0 +1,14 @@
+package providers
+
+import "net/url"
+
+var Fwf = Provider{
+	Name:       "fwf",
+	AuthHeader: "neutrino-authentication-token-expiration",
+	BaseURL: &url.URL{
+		Scheme: "https",
+		Host:   "zar.infra.fermyon.tech",
+	},
+	Path:               "/tokens.v1.TokenService/ListTokens",
+	ExpectedStatusCode: 403,
+}

--- a/providers/github.go
+++ b/providers/github.go
@@ -1,0 +1,13 @@
+package providers
+
+import "net/url"
+
+var Github = Provider{
+	Name:       "github",
+	AuthHeader: "github-authentication-token-expiration",
+	BaseURL: &url.URL{
+		Scheme: "https",
+		Host:   "api.github.com",
+	},
+	ExpectedStatusCode: 200,
+}

--- a/providers/provider.go
+++ b/providers/provider.go
@@ -1,0 +1,31 @@
+package providers
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/alecthomas/kong"
+)
+
+func (p *Provider) Decode(ctx *kong.DecodeContext) error {
+	value := ctx.Scan.Pop().String()
+	provider, ok := Providers[value]
+	if !ok {
+		return fmt.Errorf("unsupported provider: %q", value)
+	}
+	*p = provider
+	return nil
+}
+
+type Provider struct {
+	Name               string
+	AuthHeader         string
+	BaseURL            *url.URL
+	Path               string
+	ExpectedStatusCode int
+}
+
+var Providers = map[string]Provider{
+	"github": Github,
+	"fwf":    Fwf,
+}


### PR DESCRIPTION
- Updates utility with the concept of an auth `Provider`, extending support beyond GitHub
- Adds Fermyon Wasm Functions provider

TODO once/if approach is approved:
- [ ] Renaming: package, etc.  Maybe `auth-token-monitor`?
- [ ] Add/update tests?