### PR TITLE
fix(checkTokens): skip nested dirs under TokensDir

### DIFF
--- a/main.go
+++ b/main.go
@@ -117,6 +117,9 @@ func checkTokens(ctx context.Context) (err error) {
 		}
 		for _, entry := range entries {
 			path := path.Join(flags.TokensDir, entry.Name())
+			if fi, err := os.Stat(path); err == nil && fi.IsDir() {
+				continue
+			}
 			byteContents, err := os.ReadFile(path)
 			if err != nil {
 				return fmt.Errorf("reading %q: %w", path, err)


### PR DESCRIPTION
When reading entries in the supplied TokensDir, skip any nested dirs

### Context

This came up when running this monitor in the context of Kubernetes, via a Job and mounted Volume populated by a Secret.  Alas, Kubernetes appears to utilize (symlinked) directories in Secrets (and ConfigMaps), thus breaking ReadFile attempts if not skipped.

Sample:

```
$ kubectl logs -f auth-token-monitor-29571794-pfn67
Error: reading "/auth-tokens/..2026_03_23_23_14_00.309992648": read /auth-tokens/..2026_03_23_23_14_00.309992648: is a directory

$ kubectl exec -it auth-token-monitor-29571794-pfn67 -- /bin/sh
/ # ls -haltr auth-tokens/
total 4K
lrwxrwxrwx    1 root     root          30 Mar 23 23:14 my_token -> ..data/my_token
lrwxrwxrwx    1 root     root          31 Mar 23 23:14 ..data -> ..2026_03_23_23_14_00.309992648
drwxr-xr-x    2 root     root          60 Mar 23 23:14 ..2026_03_23_23_14_00.309992648
drwxrwxrwt    3 root     root         100 Mar 23 23:14 .
drwxr-xr-x    1 root     root        4.0K Mar 23 23:14 ..
```