### PR TITLE
feat/ref(*): auto-detect provider

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,8 +25,7 @@ jobs:
           FERMYBOT_GH_TEST_TOKEN: ${{ secrets.FERMYBOT_GH_TEST_TOKEN }}
           FERMYBOT_FWF_TEST_TOKEN: ${{ secrets.FERMYBOT_FWF_TEST_TOKEN }}
         run: |
-          ./auth-token-monitor --token-env-vars FERMYBOT_GH_TEST_TOKEN,GITHUB_TOKEN --expiration-threshold=0
-          ./auth-token-monitor --token-env-vars FERMYBOT_FWF_TEST_TOKEN --expiration-threshold=0 --provider fwf
+          ./auth-token-monitor --token-env-vars FERMYBOT_GH_TEST_TOKEN,FERMYBOT_FWF_TEST_TOKEN,GITHUB_TOKEN --expiration-threshold=0
 
       - name: Check Test Token expiring in next year
         env:
@@ -47,5 +46,4 @@ jobs:
           FERMYBOT_GH_TEST_TOKEN: ${{ secrets.FERMYBOT_GH_TEST_TOKEN }}
           FERMYBOT_FWF_TEST_TOKEN: ${{ secrets.FERMYBOT_FWF_TEST_TOKEN }}
         run: |
-          ./auth-token-monitor --token-env-vars FERMYBOT_GH_TEST_TOKEN --expiration-threshold=720h
-          ./auth-token-monitor --token-env-vars FERMYBOT_FWF_TEST_TOKEN --expiration-threshold=720h --provider fwf
+          ./auth-token-monitor --token-env-vars FERMYBOT_GH_TEST_TOKEN,FERMYBOT_FWF_TEST_TOKEN --expiration-threshold=720h

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ Currently supported providers:
  - `fwf` : [Fermyon Wasm Functions](https://www.fermyon.com/wasm-functions)
  - `linode` : [Linode](https://techdocs.akamai.com/linode-api/reference/get-personal-access-tokens)
 
+The provider will be auto-detected for each provided token.
+
 # Usage
 
 ## GitHub
@@ -35,7 +37,7 @@ Here we assume `TOKEN` in the shell environment holds the value of a FwF auth to
 e.g. procured via `spin aka auth tokens create --name mytoken`:
 
 ```console
-$ ./auth-token-monitor --token-env-vars TOKEN --provider fwf
+$ ./auth-token-monitor --token-env-vars TOKEN
 Checking "TOKEN" with provider "fwf"...
 Token expiration: 2026-02-14 00:04:38.312316 +0000 UTC (15.1 days)
 ```
@@ -48,7 +50,7 @@ API. It checks the expiration of all tokens returned by the API, not just the
 token used to authenticate.
 
 ```console
-$ LINODE_TOKEN="<your linode personal access token>" auth-token-monitor --provider linode --token-env-vars LINODE_TOKEN
+$ LINODE_TOKEN="<your linode personal access token>" auth-token-monitor --token-env-vars LINODE_TOKEN
 Checking "LINODE_TOKEN" with provider "linode"...
 Found 3 Linode personal access token(s)
   [my-cli-token] (id=123456): expiration: 2026-03-15T00:00:00Z (33.9 days)
@@ -64,6 +66,12 @@ exit status 1
 
 This repo publishes a lightweight container with
 [`ko`](https://github.com/ko-build/ko).
+
+You can build the image locally after `ko` is installed on your system via:
+
+```bash
+KO_DOCKER_REPO=<registry>/auth-token-monitor ko build --bare
+```
 
 ## Github Actions
 

--- a/config/config.go
+++ b/config/config.go
@@ -1,0 +1,23 @@
+package config
+
+import (
+	"net/url"
+	"time"
+)
+
+type Config struct {
+	TokenEnvVars []string `name:"token-env-vars" help:"Comma-separated list of token env var(s)"`
+	TokensDir    string   `name:"tokens-dir" help:"Directory containing mounted secret tokens"`
+
+	BaseURL             *url.URL      `name:"base-url" help:"Token API base URL (overrides provider default)"`
+	ExpirationThreshold time.Duration `name:"expiration-threshold" default:"360h" help:"Minimum duration until token expiration"`
+	Provider            string        `name:"provider" hidden:"" type:"" help:"Deprecated: the auth provider is now auto-detected from token(s)" `
+}
+
+var TimestampLayouts = []string{
+	// Sometimes Github returns an abbreviated timezone name, sometimes a numeric offset 🙄
+	"2006-01-02 15:04:05 MST",
+	"2006-01-02 15:04:05 -0700",
+	// This is the current layout for FwF
+	"2006-01-02 15:04:05.999999 -0700 MST",
+}

--- a/main.go
+++ b/main.go
@@ -1,51 +1,28 @@
 package main
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"log"
 	"maps"
-	"net/http"
-	"net/url"
 	"os"
 	"path"
 	"slices"
-	"strconv"
 	"strings"
-	"time"
 
 	"github.com/alecthomas/kong"
-	"github.com/linode/linodego"
 	"go.opentelemetry.io/contrib/exporters/autoexport"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	sdkTrace "go.opentelemetry.io/otel/sdk/trace"
-	"go.opentelemetry.io/otel/trace"
-	"golang.org/x/oauth2"
 
+	"github.com/fermyon/auth-token-monitor/config"
 	"github.com/fermyon/auth-token-monitor/providers"
 )
 
-var timestampLayouts = []string{
-	// Sometimes Github returns an abbreviated timezone name, sometimes a numeric offset 🙄
-	"2006-01-02 15:04:05 MST",
-	"2006-01-02 15:04:05 -0700",
-	// This is the current layout for FwF
-	"2006-01-02 15:04:05.999999 -0700 MST",
-}
-
-var flags struct {
-	TokenEnvVars []string `name:"token-env-vars" help:"Comma-separated list of token env var(s)"`
-	TokensDir    string   `name:"tokens-dir" help:"Directory containing mounted secret tokens"`
-
-	BaseURL             *url.URL           `name:"base-url" help:"Token API base URL (overrides provider default)"`
-	ExpirationThreshold time.Duration      `name:"expiration-threshold" default:"360h" help:"Minimum duration until token expiration"`
-	Provider            providers.Provider `name:"provider" type:"" default:"github" help:"Auth Token provider ('github', 'fwf', or 'linode')" `
-}
+var flags config.Config
 
 func main() {
 	err := run()
@@ -58,8 +35,8 @@ func main() {
 func run() error {
 	kong.Parse(&flags)
 
-	if flags.BaseURL != nil {
-		flags.Provider.BaseURL = flags.BaseURL
+	if flags.Provider != "" {
+		fmt.Fprintf(os.Stderr, "Warning: --provider is deprecated and will be ignored. The auth provider is now auto-detected for each token.\n")
 	}
 
 	ctx := context.Background()
@@ -95,7 +72,6 @@ func checkTokens(ctx context.Context) (err error) {
 		span.End()
 	}()
 	span.SetAttributes(
-		attribute.Stringer("tokmon.base_url", flags.Provider.BaseURL),
 		attribute.Float64("tokmon.expiration_threshold", flags.ExpirationThreshold.Seconds()))
 
 	tokens := map[string]string{}
@@ -151,26 +127,13 @@ func checkTokens(ctx context.Context) (err error) {
 	}
 
 	unhappyTokens := failedChecksError{}
-
-	if flags.Provider == providers.Linode {
-		for name, token := range tokens {
-			unhappy, err := checkLinodeTokens(ctx, name, token)
-			if err != nil {
-				log.Printf("Failed checking token %q: %v", name, err)
-				unhappyTokens = append(unhappyTokens, name)
-			} else {
-				unhappyTokens = append(unhappyTokens, unhappy...)
-			}
-		}
-	} else {
-		for name, token := range tokens {
-			happy, err := checkToken(ctx, name, token)
-			if err != nil {
-				log.Printf("Failed checking token %q: %v", name, err)
-			}
-			if !happy {
-				unhappyTokens = append(unhappyTokens, name)
-			}
+	for name, token := range tokens {
+		unhappy, err := checkTokensByPattern(ctx, name, token)
+		if err != nil {
+			log.Printf("Failed checking token by pattern %q: %v", name, err)
+			unhappyTokens = append(unhappyTokens, name)
+		} else {
+			unhappyTokens = append(unhappyTokens, unhappy...)
 		}
 	}
 
@@ -180,206 +143,15 @@ func checkTokens(ctx context.Context) (err error) {
 	return nil
 }
 
-func checkToken(ctx context.Context, name, token string) (happy bool, err error) {
-	ctx, span := otel.Tracer("").Start(ctx, "check "+name)
-	defer func() {
-		if err != nil {
-			span.SetStatus(codes.Error, err.Error())
-		}
-		span.End()
-	}()
-	span.SetAttributes(attribute.String("tokmon.token.name", name))
-
-	fmt.Printf("Checking %q with provider %q...\n", name, flags.Provider.Name)
-
-	// Make request to check token
-	url := flags.Provider.BaseURL.JoinPath(flags.Provider.Path).String()
-	resp, _, err := request(ctx, url, token)
-	if err != nil {
-		return false, fmt.Errorf("checking token via url %s: %w", url, err)
-	}
-
-	// Get user info (if permitted)
-	// TODO: Currently only valid with GitHub; request support in FwF as well?
-	userURL := flags.Provider.BaseURL.JoinPath("user").String()
-	_, userJSON, err := request(ctx, userURL, token)
-	if err == nil {
-		// Parse user login
-		var user struct {
-			Login string `json:"login"`
-		}
-		err = json.Unmarshal(userJSON, &user)
-		if err != nil {
-			return false, fmt.Errorf("deserializing user: %w", err)
-		}
-		span.SetAttributes(attribute.String("tokmon.token.login", user.Login))
-		fmt.Printf("Token user login: %s\n", user.Login)
-	}
-
-	happy = true
-
-	// Check token expiration
-	expirationValue := resp.Header.Get(flags.Provider.AuthHeader)
-	if expirationValue == "" {
-		fmt.Println("Token expiration: NONE")
-	} else {
-		span.SetAttributes(attribute.String("tokmon.token.expiration", expirationValue))
-
-		// Parse expiration timestamp
-		var expiration time.Time
-		var err error
-		for _, layout := range timestampLayouts {
-			expiration, err = time.Parse(layout, expirationValue)
-			if err == nil {
-				break
+func checkTokensByPattern(ctx context.Context, name, token string) (unhappyTokens []string, err error) {
+	for _, provider := range providers.Providers {
+		for _, pattern := range provider.GetPatterns() {
+			if pattern.MatchString(token) {
+				return provider.CheckToken(ctx, &flags, name, token)
 			}
 		}
-		if err != nil {
-			return false, fmt.Errorf("invalid expiration header value %q: %w", expirationValue, err)
-		}
-		fmt.Printf("Token expiration: %s", expiration)
-
-		// Calculate time until expiration
-		expirationDuration := time.Until(expiration)
-		span.SetAttributes(attribute.Float64("tokmon.token.expiration_duration", expirationDuration.Seconds()))
-		fmt.Printf(" (%.1f days)\n", expirationDuration.Hours()/24)
-		if expirationDuration < flags.ExpirationThreshold {
-			fmt.Println("WARNING: Expiring soon!")
-			happy = false
-			span.SetStatus(codes.Error, "token expiring soon")
-		}
-
 	}
-
-	// Check rate limit usage
-	rateLimitLimit, _ := strconv.Atoi(resp.Header.Get("x-ratelimit-limit"))
-	if rateLimitLimit != 0 {
-		rateLimitUsed, _ := strconv.Atoi(resp.Header.Get("x-ratelimit-used"))
-		fmt.Printf("Rate limit usage: %d / %d", rateLimitUsed, rateLimitLimit)
-
-		rateLimitPercent := rateLimitUsed * 100 / rateLimitLimit
-		fmt.Printf(" (~%d%%)\n", rateLimitPercent)
-		if rateLimitPercent > 50 {
-			fmt.Println("WARNING: Rate limit >50%!")
-			span.SetStatus(codes.Error, "high rate limit usage")
-			happy = false
-		}
-	}
-
-	// Get GitHub token permissions (sometimes helpful when rotating)
-	if flags.Provider == providers.Github {
-		oAuthScopes := resp.Header.Get("x-oauth-scopes")
-		span.SetAttributes(attribute.String("tokmon.token.oauth_scopes", oAuthScopes))
-		fmt.Printf("OAuth scopes: %s\n\n", oAuthScopes)
-	}
-	return happy, nil
-}
-
-func checkLinodeTokens(ctx context.Context, name, token string) (unhappyTokens []string, err error) {
-	ctx, span := otel.Tracer("").Start(ctx, "check-linode "+name)
-	defer func() {
-		if err != nil {
-			span.SetStatus(codes.Error, err.Error())
-		}
-		span.End()
-	}()
-	span.SetAttributes(attribute.String("tokmon.token.name", name))
-
-	fmt.Printf("Checking %q with provider %q...\n", name, flags.Provider.Name)
-
-	// Create a linodego client using the token
-	tokenSource := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token})
-	oauthClient := oauth2.NewClient(ctx, tokenSource)
-	client := linodego.NewClient(oauthClient)
-	if flags.Provider.BaseURL != nil {
-		client.SetBaseURL(flags.Provider.BaseURL.String())
-	}
-
-	// List all personal access tokens visible to this token
-	linodeTokens, err := client.ListTokens(ctx, nil)
-	if err != nil {
-		return nil, fmt.Errorf("listing Linode tokens: %w", err)
-	}
-
-	fmt.Printf("Found %d Linode personal access token(s)\n", len(linodeTokens))
-	span.SetAttributes(attribute.Int("tokmon.linode.token_count", len(linodeTokens)))
-
-	for _, lt := range linodeTokens {
-		label := lt.Label
-		if label == "" {
-			label = fmt.Sprintf("token-%d", lt.ID)
-		}
-		span.AddEvent("check_linode_token", trace.WithAttributes(
-			attribute.String("tokmon.linode.token_label", label),
-			attribute.Int("tokmon.linode.token_id", lt.ID),
-		))
-
-		if lt.Expiry == nil {
-			fmt.Printf("  [%s] (id=%d): expiration: NEVER\n", label, lt.ID)
-			continue
-		}
-
-		expiration := *lt.Expiry
-		expirationDuration := time.Until(expiration)
-		fmt.Printf("  [%s] (id=%d): expiration: %s (%.1f days)\n",
-			label, lt.ID, expiration.Format(time.RFC3339), expirationDuration.Hours()/24)
-
-		if expirationDuration < flags.ExpirationThreshold {
-			fmt.Printf("  WARNING: Token %q expiring soon!\n", label)
-			unhappyTokens = append(unhappyTokens, label)
-			span.SetStatus(codes.Error, fmt.Sprintf("linode token %q expiring soon", label))
-		}
-	}
-
-	fmt.Println()
-	return unhappyTokens, nil
-}
-
-func request(ctx context.Context, url, token string) (resp *http.Response, body []byte, err error) {
-	ctx, span := otel.Tracer("").Start(ctx, url)
-	defer func() {
-		if err != nil {
-			span.SetStatus(codes.Error, err.Error())
-		}
-		span.End()
-	}()
-
-	var req *http.Request
-	switch flags.Provider {
-	case providers.Fwf:
-		body := []byte(`{}`)
-		req, err = http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(body))
-		if err != nil {
-			return nil, nil, fmt.Errorf("new request: %w", err)
-		}
-		req.Header.Set("Content-Type", "application/json")
-	default:
-		req, err = http.NewRequestWithContext(ctx, "GET", url, nil)
-		if err != nil {
-			return nil, nil, fmt.Errorf("new request: %w", err)
-		}
-	}
-	req.Header.Set("Authorization", "Bearer "+token)
-
-	resp, err = http.DefaultClient.Do(req)
-	if err != nil {
-		return nil, nil, fmt.Errorf("do request: %w", err)
-	}
-	defer resp.Body.Close()
-
-	body, err = io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, nil, fmt.Errorf("reading body: %w", err)
-	}
-
-	if resp.StatusCode != flags.Provider.ExpectedStatusCode {
-		if len(body) > 1024 {
-			body = body[:1024]
-		}
-		trace.SpanFromContext(ctx).SetAttributes(attribute.String("tokmon.error_body", strconv.QuoteToASCII(string(body))))
-		return nil, nil, fmt.Errorf("got status code %d != %d", resp.StatusCode, flags.Provider.ExpectedStatusCode)
-	}
-	return
+	return unhappyTokens, fmt.Errorf("could not determine provider")
 }
 
 type failedChecksError []string

--- a/providers/fwf.go
+++ b/providers/fwf.go
@@ -1,14 +1,26 @@
 package providers
 
-import "net/url"
+import (
+	"net/url"
+	"regexp"
+)
 
-var Fwf = Provider{
-	Name:       "fwf",
-	AuthHeader: "neutrino-authentication-token-expiration",
-	BaseURL: &url.URL{
-		Scheme: "https",
-		Host:   "zar.infra.fermyon.tech",
+type FwfProvider struct {
+	Provider
+}
+
+var Fwf = &FwfProvider{
+	Provider: Provider{
+		Name:       "fwf",
+		AuthHeader: "neutrino-authentication-token-expiration",
+		BaseURL: &url.URL{
+			Scheme: "https",
+			Host:   "zar.infra.fermyon.tech",
+		},
+		Path:               "/tokens.v1.TokenService/ListTokens",
+		ExpectedStatusCode: 403,
+		TokenPatterns: []*regexp.Regexp{
+			regexp.MustCompile(`^pat_[A-Z2-7]{26}$`),
+		},
 	},
-	Path:               "/tokens.v1.TokenService/ListTokens",
-	ExpectedStatusCode: 403,
 }

--- a/providers/github.go
+++ b/providers/github.go
@@ -1,13 +1,30 @@
 package providers
 
-import "net/url"
+import (
+	"net/url"
+	"regexp"
+)
 
-var Github = Provider{
-	Name:       "github",
-	AuthHeader: "github-authentication-token-expiration",
-	BaseURL: &url.URL{
-		Scheme: "https",
-		Host:   "api.github.com",
+type GithubProvider struct {
+	Provider
+}
+
+var Github = &GithubProvider{
+	Provider: Provider{
+		Name:       "github",
+		AuthHeader: "github-authentication-token-expiration",
+		BaseURL: &url.URL{
+			Scheme: "https",
+			Host:   "api.github.com",
+		},
+		ExpectedStatusCode: 200,
+		TokenPatterns: []*regexp.Regexp{
+			// classic
+			regexp.MustCompile(`^ghp_[a-zA-Z0-9]{36}$`),
+			// fine-grained
+			regexp.MustCompile(`^github_pat_[a-zA-Z0-9]{22}_[a-zA-Z0-9]{59}$`),
+			// ephemeral Action tokens eg GITHUB_TOKEN
+			regexp.MustCompile(`^ghs_[a-zA-Z0-9]{36}$`),
+		},
 	},
-	ExpectedStatusCode: 200,
 }

--- a/providers/linode.go
+++ b/providers/linode.go
@@ -1,11 +1,98 @@
 package providers
 
-import "net/url"
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"regexp"
+	"time"
 
-var Linode = Provider{
-	Name: "linode",
-	BaseURL: &url.URL{
-		Scheme: "https",
-		Host:   "api.linode.com",
+	"github.com/linode/linodego"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+	"golang.org/x/oauth2"
+
+	"github.com/fermyon/auth-token-monitor/config"
+)
+
+type LinodeProvider struct {
+	Provider
+}
+
+var Linode = &LinodeProvider{
+	Provider: Provider{
+		Name: "linode",
+		BaseURL: &url.URL{
+			Scheme: "https",
+			Host:   "api.linode.com",
+		},
+		TokenPatterns: []*regexp.Regexp{
+			regexp.MustCompile(`^[a-f0-9]{64}$`),
+		},
 	},
+}
+
+func (lp *LinodeProvider) CheckToken(ctx context.Context, cfg *config.Config, name, token string) (unhappyTokens []string, err error) {
+	if cfg.BaseURL != nil {
+		lp.BaseURL = cfg.BaseURL
+	}
+	ctx, span := otel.Tracer("").Start(ctx, fmt.Sprintf("check-%s %s", lp.Name, name))
+	defer func() {
+		if err != nil {
+			span.SetStatus(codes.Error, err.Error())
+		}
+		span.End()
+	}()
+	span.SetAttributes(
+		attribute.Stringer("tokmon.base_url", lp.BaseURL),
+		attribute.String("tokmon.token.name", name))
+
+	fmt.Printf("Checking token %q with provider %q...\n", name, lp.Name)
+
+	// Create a linodego client using the token
+	tokenSource := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token})
+	oauthClient := oauth2.NewClient(ctx, tokenSource)
+	client := linodego.NewClient(oauthClient)
+	client.SetBaseURL(lp.BaseURL.String())
+
+	// List all personal access tokens visible to this token
+	linodeTokens, err := client.ListTokens(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("listing Linode tokens: %w", err)
+	}
+
+	fmt.Printf("Found %d Linode personal access token(s)\n", len(linodeTokens))
+	span.SetAttributes(attribute.Int("tokmon.linode.token_count", len(linodeTokens)))
+
+	for _, lt := range linodeTokens {
+		label := lt.Label
+		if label == "" {
+			label = fmt.Sprintf("token-%d", lt.ID)
+		}
+		span.AddEvent("check_linode_token", trace.WithAttributes(
+			attribute.String("tokmon.linode.token_label", label),
+			attribute.Int("tokmon.linode.token_id", lt.ID),
+		))
+
+		if lt.Expiry == nil {
+			fmt.Printf("  [%s] (id=%d): expiration: NEVER\n", label, lt.ID)
+			continue
+		}
+
+		expiration := *lt.Expiry
+		expirationDuration := time.Until(expiration)
+		fmt.Printf("  [%s] (id=%d): expiration: %s (%.1f days)\n",
+			label, lt.ID, expiration.Format(time.RFC3339), expirationDuration.Hours()/24)
+
+		if expirationDuration < cfg.ExpirationThreshold {
+			fmt.Printf("  WARNING: Token %q expiring soon!\n", label)
+			unhappyTokens = append(unhappyTokens, label)
+			span.SetStatus(codes.Error, fmt.Sprintf("linode token %q expiring soon", label))
+		}
+	}
+
+	fmt.Println()
+	return unhappyTokens, nil
 }

--- a/providers/provider.go
+++ b/providers/provider.go
@@ -1,21 +1,23 @@
 package providers
 
 import (
+	"bytes"
+	"context"
+	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
 	"net/url"
+	"regexp"
+	"strconv"
+	"time"
 
-	"github.com/alecthomas/kong"
+	"github.com/fermyon/auth-token-monitor/config"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
 )
-
-func (p *Provider) Decode(ctx *kong.DecodeContext) error {
-	value := ctx.Scan.Pop().String()
-	provider, ok := Providers[value]
-	if !ok {
-		return fmt.Errorf("unsupported provider: %q", value)
-	}
-	*p = provider
-	return nil
-}
 
 type Provider struct {
 	Name               string
@@ -23,10 +25,166 @@ type Provider struct {
 	BaseURL            *url.URL
 	Path               string
 	ExpectedStatusCode int
+	TokenPatterns      []*regexp.Regexp
 }
 
-var Providers = map[string]Provider{
+var Providers = map[string]TokenChecker{
 	"github": Github,
 	"fwf":    Fwf,
 	"linode": Linode,
+}
+
+type TokenChecker interface {
+	CheckToken(ctx context.Context, config *config.Config, name, token string) (unhappyTokens []string, err error)
+	GetPatterns() (tokenPatterns []*regexp.Regexp)
+}
+
+func (p *Provider) CheckToken(ctx context.Context, cfg *config.Config, name, token string) (unhappyTokens []string, err error) {
+	if cfg.BaseURL != nil {
+		p.BaseURL = cfg.BaseURL
+	}
+	ctx, span := otel.Tracer("").Start(ctx, fmt.Sprintf("check-%s %s", p.Name, name))
+	defer func() {
+		if err != nil {
+			span.SetStatus(codes.Error, err.Error())
+		}
+		span.End()
+	}()
+	span.SetAttributes(
+		attribute.Stringer("tokmon.base_url", p.BaseURL),
+		attribute.String("tokmon.token.name", name))
+
+	fmt.Printf("Checking token %q with provider %q...\n", name, p.Name)
+
+	// Make request to check token
+	url := p.BaseURL.JoinPath(p.Path).String()
+	resp, _, err := p.request(ctx, url, token)
+	if err != nil {
+		return unhappyTokens, fmt.Errorf("checking token via url %s: %w", url, err)
+	}
+
+	// Get user info (if permitted)
+	userURL := p.BaseURL.JoinPath("user").String()
+	_, userJSON, err := p.request(ctx, userURL, token)
+	if err == nil {
+		// Parse user login
+		var user struct {
+			Login string `json:"login"`
+		}
+		err = json.Unmarshal(userJSON, &user)
+		if err != nil {
+			return unhappyTokens, fmt.Errorf("deserializing user: %w", err)
+		}
+		span.SetAttributes(attribute.String("tokmon.token.login", user.Login))
+		fmt.Printf("Token user login: %s\n", user.Login)
+	}
+
+	// Check token expiration
+	expirationValue := resp.Header.Get(p.AuthHeader)
+	if expirationValue == "" {
+		fmt.Println("Token expiration: NONE")
+	} else {
+		span.SetAttributes(attribute.String("tokmon.token.expiration", expirationValue))
+
+		// Parse expiration timestamp
+		var expiration time.Time
+		var err error
+		for _, layout := range config.TimestampLayouts {
+			expiration, err = time.Parse(layout, expirationValue)
+			if err == nil {
+				break
+			}
+		}
+		if err != nil {
+			return unhappyTokens, fmt.Errorf("invalid expiration header value %q: %w", expirationValue, err)
+		}
+		fmt.Printf("Token expiration: %s", expiration)
+
+		// Calculate time until expiration
+		expirationDuration := time.Until(expiration)
+		span.SetAttributes(attribute.Float64("tokmon.token.expiration_duration", expirationDuration.Seconds()))
+		fmt.Printf(" (%.1f days)\n", expirationDuration.Hours()/24)
+		if expirationDuration < cfg.ExpirationThreshold {
+			fmt.Println("WARNING: Expiring soon!")
+			unhappyTokens = append(unhappyTokens, token)
+			span.SetStatus(codes.Error, "token expiring soon")
+		}
+
+	}
+
+	// Check rate limit usage
+	rateLimitLimit, _ := strconv.Atoi(resp.Header.Get("x-ratelimit-limit"))
+	if rateLimitLimit != 0 {
+		rateLimitUsed, _ := strconv.Atoi(resp.Header.Get("x-ratelimit-used"))
+		fmt.Printf("Rate limit usage: %d / %d", rateLimitUsed, rateLimitLimit)
+
+		rateLimitPercent := rateLimitUsed * 100 / rateLimitLimit
+		fmt.Printf(" (~%d%%)\n", rateLimitPercent)
+		if rateLimitPercent > 50 {
+			fmt.Println("WARNING: Rate limit >50%!")
+			span.SetStatus(codes.Error, "high rate limit usage")
+			unhappyTokens = append(unhappyTokens, token)
+		}
+	}
+
+	// Get GitHub token permissions (sometimes helpful when rotating)
+	if p.Name == Github.Name {
+		oAuthScopes := resp.Header.Get("x-oauth-scopes")
+		span.SetAttributes(attribute.String("tokmon.token.oauth_scopes", oAuthScopes))
+		fmt.Printf("OAuth scopes: %s\n", oAuthScopes)
+	}
+
+	fmt.Println()
+	return unhappyTokens, nil
+}
+
+func (p *Provider) GetPatterns() []*regexp.Regexp {
+	return p.TokenPatterns
+}
+
+func (p *Provider) request(ctx context.Context, url, token string) (resp *http.Response, body []byte, err error) {
+	ctx, span := otel.Tracer("").Start(ctx, url)
+	defer func() {
+		if err != nil {
+			span.SetStatus(codes.Error, err.Error())
+		}
+		span.End()
+	}()
+
+	var req *http.Request
+	switch p.Name {
+	case Fwf.Name:
+		body := []byte(`{}`)
+		req, err = http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(body))
+		if err != nil {
+			return nil, nil, fmt.Errorf("new request: %w", err)
+		}
+		req.Header.Set("Content-Type", "application/json")
+	default:
+		req, err = http.NewRequestWithContext(ctx, "GET", url, nil)
+		if err != nil {
+			return nil, nil, fmt.Errorf("new request: %w", err)
+		}
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, nil, fmt.Errorf("do request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err = io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, nil, fmt.Errorf("reading body: %w", err)
+	}
+
+	if resp.StatusCode != p.ExpectedStatusCode {
+		if len(body) > 1024 {
+			body = body[:1024]
+		}
+		trace.SpanFromContext(ctx).SetAttributes(attribute.String("tokmon.error_body", strconv.QuoteToASCII(string(body))))
+		return nil, nil, fmt.Errorf("got status code %d != %d", resp.StatusCode, p.ExpectedStatusCode)
+	}
+	return
 }


### PR DESCRIPTION
Updates this utility to automatically detect the correct (supported) provider based on each token provided.

In doing so, I refactored things; mostly moving token checking and request logic closer to each provider, with base implementations that can be used if special logic is not needed.

As of the latest commit, this is a breaking change, as it drops the `--provider` flag/arg.  If we like the looks of this change but would rather not break things, it shouldn't be too hard to add it back, perhaps with a deprecation warning.  Thoughts?