### PR TITLE
o11y(providers): include token IDs/names in error message for applicable providers

### DIFF
--- a/providers/linode.go
+++ b/providers/linode.go
@@ -99,7 +99,10 @@ func (lp *LinodeProvider) CheckToken(ctx context.Context, cfg *config.Config, na
 		if expirationDuration < cfg.ExpirationThreshold {
 			fmt.Printf("  WARNING: Token %q expiring soon!\n", label)
 			unhappyTokens = append(unhappyTokens, label)
-			span.SetStatus(codes.Error, fmt.Sprintf("linode token %q expiring soon", label))
+		}
+
+		if len(unhappyTokens) > 0 {
+			span.SetStatus(codes.Error, fmt.Sprintf("linode token(s) expiring soon: %+v", unhappyTokens))
 		}
 	}
 

--- a/providers/tailscale.go
+++ b/providers/tailscale.go
@@ -145,9 +145,12 @@ func (tp *TailscaleProvider) CheckToken(ctx context.Context, cfg *config.Config,
 
 		if expirationDuration < cfg.ExpirationThreshold {
 			fmt.Printf("  WARNING: Key %q (id=%s) expiring soon!\n", key.Description, key.ID)
-			unhappyTokens = append(unhappyTokens, key.Description)
-			span.SetStatus(codes.Error, fmt.Sprintf("tailscale key %q (id=%s) expiring soon", key.Description, key.ID))
+			unhappyTokens = append(unhappyTokens, key.ID)
 		}
+	}
+
+	if len(unhappyTokens) > 0 {
+		span.SetStatus(codes.Error, fmt.Sprintf("tailscale key(s) expiring soon: %+v", unhappyTokens))
 	}
 
 	fmt.Println()


### PR DESCRIPTION
Some providers may return multiple 'unhappy' tokens (eg expired or within the configured expiration threshold) for a given span, so this updates logic to collect them all, instead of assigning the span error to the single, last errored token (as is currently the case).

Although each erroring token is already submitted as an Event on the Span, I found it useful to aggregate these into the overall span error message.  There are also cases (eg the Tailscale provider) where the provided authentication token is perfectly 'happy', yet token(s) elsewhere in the tailnet cause error(s) (maybe Linode as well, not sure).